### PR TITLE
Use unsafeInterleaveIO and atomicModifyIORef, fixes (#5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,6 @@ env:
 
 matrix:
   include:
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons:
-      apt:
-        packages:
-        - cabal-install-1.18
-        - ghc-7.8.4
-        - happy-1.19.5
-        - alex-3.1.7
-        sources:
-        - hvr-ghc
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
     addons:
@@ -62,14 +51,6 @@ matrix:
       apt:
         packages:
         - ghc-7.10.3
-        sources:
-        - hvr-ghc
-  - env: BUILD=stack ARGS="--resolver lts-2 --stack-yaml stack-lts2.yaml"
-    compiler: ": #stack 7.8.4"
-    addons:
-      apt:
-        packages:
-        - ghc-7.8.4
         sources:
         - hvr-ghc
   - env: BUILD=stack ARGS="--resolver lts-3"

--- a/monad-metrics.cabal
+++ b/monad-metrics.cabal
@@ -1,5 +1,5 @@
 name:                monad-metrics
-version:             0.1.0.2
+version:             0.2.0.0
 synopsis:            A convenient wrapper around EKG metrics
 description:         A convenient wrapper for collecting application metrics. Please see the README.md for more information.
 homepage:            https://github.com/sellerlabs/monad-metrics#readme

--- a/monad-metrics.cabal
+++ b/monad-metrics.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Control.Monad.Metrics
                      , Control.Monad.Metrics.Internal
-  build-depends:       base                 >= 4.7     && < 5
+  build-depends:       base                 >= 4.8     && < 5
                      , clock                >= 0.3     && < 0.8
                      , ekg-core             >= 0.1.0.1 && < 0.2
                      , hashable             >= 1.2     && < 1.3
@@ -32,7 +32,7 @@ test-suite monad-metrics-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  build-depends:       base             >= 4.6 && <= 5.0
+  build-depends:       base             >= 4.8 && <= 5.0
                      , monad-metrics
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/src/Control/Monad/Metrics.hs
+++ b/src/Control/Monad/Metrics.hs
@@ -264,7 +264,6 @@ lookupOrCreate
     => (Metrics -> IORef (Map k a)) -> (k -> EKG.Store -> IO a) -> k -> m a
 lookupOrCreate getter creator name = do
     ref <- liftM getter getMetrics
-    container <- liftIO $ readIORef ref
     -- unsafeInterleaveIO is used here to defer creating the metric into
     -- the 'atomicModifyIORef'' function. We lazily create the value here,
     -- and the resulting IO action only gets run to create the metric when

--- a/src/Control/Monad/Metrics.hs
+++ b/src/Control/Monad/Metrics.hs
@@ -58,11 +58,11 @@ import           Control.Monad.Trans            (MonadTrans (..))
 import           Data.Hashable                  (Hashable)
 import           Data.HashMap.Strict            (HashMap)
 import qualified Data.HashMap.Strict            as HashMap
-import           Data.IORef
+import           Data.IORef                     (IORef, atomicModifyIORef',
+                                                 newIORef)
 import           Data.Monoid                    (mempty)
 import           Data.Text                      (Text)
 import qualified Data.Text                      as Text
-import           Lens.Micro
 import           System.Clock                   (Clock (..), TimeSpec (..),
                                                  getTime)
 import           System.IO.Unsafe               (unsafeInterleaveIO)

--- a/src/Control/Monad/Metrics.hs
+++ b/src/Control/Monad/Metrics.hs
@@ -273,6 +273,6 @@ lookupOrCreate getter creator name = do
     liftIO $ atomicModifyIORef' ref (\container ->
         case Map.lookup name container of
             Nothing ->
-                (newMetric, Map.insert name newMetric container)
+                (Map.insert name newMetric container, newMetric)
             Just metric ->
-                (metric, container))
+                (container, metric))


### PR DESCRIPTION
This should be a safe usage of unsafeInterleaveIO. We use it to defer
the IO computation that creates the metric until we know the metric is
not present. This allows us to use atomicModifyIORef, which fixes a race
condition issue.