### PR TITLE
Implement `Map` vs. `HashMap` benchmark

### DIFF
--- a/bench/Map.hs
+++ b/bench/Map.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Prelude hiding (map)
+import Data.Monoid ((<>))
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Text (Text, pack)
+
+import System.Metrics (createCounter, createDistribution, createGauge, createLabel, newStore, registerGcMetrics)
+
+import Criterion (bgroup, bench, whnf)
+import Criterion.Main (defaultMain)
+
+main :: IO ()
+main = do
+    store <- newStore
+    -- Add 'standard' metrics
+    registerGcMetrics store
+
+    -- Add 'application-specific' metrics
+    -- Admittedly, using the same prefix isn't great...
+    metrics <- mapM (\i -> let name = "monad-logger.bench.counter" <> pack (show i) in
+                           createCounter name store >>= \metric -> return (name, metric))
+                    [1..100]
+
+    let map = Map.fromList metrics
+        hashMap = HashMap.fromList metrics
+        key = "monad-logger.bench.counter50"
+
+    defaultMain [
+        bgroup "Map" [
+            bench "lookup" $ whnf (flip Map.lookup map) key
+          ]
+      , bgroup "HashMap" [
+            bench "lookup" $ whnf (flip HashMap.lookup hashMap) key
+          ]
+      ]

--- a/monad-metrics.cabal
+++ b/monad-metrics.cabal
@@ -36,6 +36,19 @@ test-suite monad-metrics-test
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+benchmark monad-metrics-bench
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             Map.hs
+  build-depends:       base                 >= 4.9 && < 4.10
+                     , containers           >= 0.5 && < 0.6
+                     , criterion            >= 1.1 && < 1.2
+                     , ekg-core             >= 0.1 && < 0.2
+                     , text                 >= 1.2 && < 1.3
+                     , unordered-containers >= 0.2 && < 0.3
+  ghc-options:         -rtsopts
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/sellerlabs/monad-metrics


### PR DESCRIPTION
`monad-metrics` keeps `Counter`s, `Gauge`s and others in a `Map`, using
the metric name (`Text`) as key.

Using `HashMap` from `unordered-containers` instead seems to give a
performance improvement for `lookup`, which is a common operation:

```
tack --resolver=lts-9.0 bench
monad-metrics-0.1.0.2: benchmarks
Running 1 benchmarks...
Benchmark monad-metrics-bench: RUNNING...
benchmarking Map/lookup
time                 373.0 ns   (371.3 ns .. 375.2 ns)
                             1.000 R²   (1.000 R² .. 1.000 R²)
mean                 372.6 ns   (371.7 ns .. 374.2 ns)
std dev              3.976 ns   (2.218 ns .. 6.173 ns)

benchmarking HashMap/lookup
time                 98.26 ns   (98.00 ns .. 98.60 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 98.21 ns   (98.04 ns .. 98.62 ns)
std dev              883.0 ps   (412.2 ps .. 1.770 ns)

Benchmark monad-metrics-bench: FINISH
```

Admittedly, the benchmark is slightly contrived because of the common
prefix of the generated metric names.