### PR TITLE
Add a method to store action duration under several names at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming...
 
+- Introduced `timedList` method, to store the same distribution data under several names at once.
+
 ## v0.2.0.0 
 
 - Make `timed` and `timed'` require a `MonadMask` constraint for bracketing.


### PR DESCRIPTION
In some applications, it is interesting to see distribution of action duration sectioned by different criteria. For example, if I have requests of different types, from different users, I may want to see distributions

1) of all requests
2) of requests of specific user
3) of requests of specific type
4) of requests of specific user of specific type.

Task 1 is solved by `timed "request.duration" $ do...`. Task 4 is solved by 

    timed ("request.byUser." <> userName <> ".byType." <> requestType) $ do ...

It is tempting to say that results of tasks 2 and 3 can be inferred from results from task 4, but it is not easy at all; to correctly calculate "mean", we have to calculate weighted mean, and "variance" is not linear at all. So, to correctly gather data for tasks 2 and 3, we have to store duration of each execution under several names at once.

This PR introduces new function `timedList`:

    timedList Seconds ["request.byUser." <> userName, "request.byType." <> requestType] $ do ...

`timed'` method is now implemented as an obvious specialization of `timedList`.

Please review.