### PR TITLE
Add timedListWith

### DIFF
--- a/src/Control/Monad/Metrics.hs
+++ b/src/Control/Monad/Metrics.hs
@@ -40,6 +40,7 @@ module Control.Monad.Metrics
     , timed
     , timed'
     , timedList
+    , timedListWith
     , label
     , label'
     , Resolution(..)


### PR DESCRIPTION
This PR adds the `timedListWith` function (not sure about the name though) with the following signature:

```haskell
timedListWith
  :: (MonadIO m, MonadMetrics m, MonadMask m)
  => (Text -> Double -> m ())
  -> Resolution
  -> [Text]
  -> m a
  -> m a
```

This is a non-breaking change.

**Rationale**

Sometimes I want to send metrics to some other place, for example, to Prometheus:

```haskell
Prometheus.observe hist timeTaken
```

Where the `timeTaken` is `diffTime resolution end start` from the `timedList` function.

The new `timedListWith` function takes a callback, so there is no need calculate the `diffTime` twice if the user wants to send this metric somewhere else.
